### PR TITLE
Add `nomod` and `ro` options to javap buffer

### DIFF
--- a/plugin/javap.vim
+++ b/plugin/javap.vim
@@ -30,4 +30,5 @@ function! JavapCurrentBuffer()
     normal! ggdd
     set filetype=java " TODO: doesn't work for zipfile:*/*.class
     setlocal nobin
+    setlocal nomod ro
 endfunction


### PR DESCRIPTION
So there will be no "E37: No write since last change (add ! to override)" warning.